### PR TITLE
optimised buildBrainUrl

### DIFF
--- a/lib/device/brain/index.js
+++ b/lib/device/brain/index.js
@@ -12,10 +12,7 @@ let brainNotification;
 let brainNotificationMapping;
 
 function buildBrainUrl(brain) {
-  if (brain.host && brain.port) {
-    return PROTOCOL + brain.host + ':' + brain.port;
-  }
-  return PROTOCOL + brain + ':' + DEFAULT_BRAIN_PORT;
+  return PROTOCOL + brain.host || brain + ':' + brain.port || DEFAULT_BRAIN_PORT;
 }
 
 module.exports.start = function(conf) {

--- a/lib/device/brain/index.js
+++ b/lib/device/brain/index.js
@@ -12,7 +12,7 @@ let brainNotification;
 let brainNotificationMapping;
 
 function buildBrainUrl(brain) {
-  return PROTOCOL + brain.host || brain + ':' + brain.port || DEFAULT_BRAIN_PORT;
+  return PROTOCOL + (brain.host || brain) + ':' + (brain.port || DEFAULT_BRAIN_PORT);
 }
 
 module.exports.start = function(conf) {


### PR DESCRIPTION
it looks like this method was originally supporting the ability to just pass the IP and not the PORT, but has since changed. Refactored to maintain backwards compatibility, but also fix a potential issue if brain.host is set but brain.port is not.