### PR TITLE
Added MEDIAPLAYER as devicetype

### DIFF
--- a/lib/device/devicetype/index.js
+++ b/lib/device/devicetype/index.js
@@ -3,7 +3,8 @@
 // currently the supported devicetypes are very restrictive, will be enhanced soon
 const TYPES = [
   'ACCESSOIRE',
-  'LIGHT'
+  'LIGHT',
+  'MEDIAPLAYER'
 ];
 
 function isDefaultDeviceType(type) {


### PR DESCRIPTION
To support the kodi mediaplayer SDK examples. the mediaplayer device type is required.