### PR TITLE
Fix duplicate Urlbuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ If you're looking for examples, take a look at the example repository at https:/
 ## SDK Documentation
 
 See https://neeoinc.github.io/neeo-sdk/
+
+test

--- a/README.md
+++ b/README.md
@@ -15,5 +15,3 @@ If you're looking for examples, take a look at the example repository at https:/
 ## SDK Documentation
 
 See https://neeoinc.github.io/neeo-sdk/
-
-test

--- a/lib/device/brain/index.js
+++ b/lib/device/brain/index.js
@@ -5,24 +5,16 @@ const BrainRegister = require('./register.js');
 const BrainNotification = require('./notification.js');
 const BrainNotificationMapping = require('./notificationMapping.js');
 const debug = require('debug')('neeo:device:brain:BrainIndex');
+const urlbuilder = require('./urlbuilder.js');
 
-const DEFAULT_BRAIN_PORT = 3000;
-const PROTOCOL = 'http://';
 let brainNotification;
 let brainNotificationMapping;
-
-function buildBrainUrl(brain) {
-  if (brain.host && brain.port) {
-    return PROTOCOL + brain.host + ':' + brain.port;
-  }
-  return PROTOCOL + brain + ':' + DEFAULT_BRAIN_PORT;
-}
 
 module.exports.start = function(conf) {
   if (!conf || !conf.brain || !conf.baseUrl || !conf.adapterName) {
     return BluePromise.reject(new Error('BRAIN_INVALID_PARAMETER_REGISTER'));
   }
-  const urlPrefix = buildBrainUrl(conf.brain);
+  const urlPrefix = urlbuilder.buildBrainUrl(conf.brain);
   brainNotification = new BrainNotification({ url: urlPrefix });
   brainNotificationMapping = new BrainNotificationMapping({ url: urlPrefix, adapterName: conf.adapterName });
   return BrainRegister.registerAdapterOnTheBrain({ url: urlPrefix, baseUrl: conf.baseUrl, adapterName: conf.adapterName });
@@ -32,7 +24,7 @@ module.exports.stop = function(conf) {
   if (!conf || !conf.brain || !conf.adapterName) {
     return BluePromise.reject(new Error('BRAIN_INVALID_PARAMETER_UNREGISTER'));
   }
-  const urlPrefix = buildBrainUrl(conf.brain);
+  const urlPrefix = urlbuilder.buildBrainUrl(conf.brain);
   brainNotification = null;
   brainNotificationMapping = null;
   return BrainRegister.unregisterAdapterOnTheBrain({ url: urlPrefix, adapterName: conf.adapterName });

--- a/lib/device/brain/urlbuilder.js
+++ b/lib/device/brain/urlbuilder.js
@@ -12,6 +12,6 @@ module.exports.buildBrainUrl = function(brain, baseUrl) {
   } else if (typeof brain === 'string'){
     return PROTOCOL + brain + ':' + DEFAULT_BRAIN_PORT + baseUrl;
   } else {
-    return new Error("URLBUILDER_INVALID_PARAMETER_BRAIN");
+    return new Error('URLBUILDER_INVALID_PARAMETER_BRAIN');
   }
 };

--- a/lib/device/brain/urlbuilder.js
+++ b/lib/device/brain/urlbuilder.js
@@ -5,7 +5,7 @@ const PROTOCOL = 'http://';
 
 module.exports.buildBrainUrl = function(brain, baseUrl) {
   if (!brain){
-    return new Error('URLBUILDER_MISSING_PARAMETER_BRAIN');
+    throw new Error('URLBUILDER_MISSING_PARAMETER_BRAIN');
   }
   if (!baseUrl){
     baseUrl='';
@@ -15,6 +15,6 @@ module.exports.buildBrainUrl = function(brain, baseUrl) {
   } else if (typeof brain === 'string'){
     return PROTOCOL + brain + ':' + DEFAULT_BRAIN_PORT + baseUrl;
   } else {
-    return new Error('URLBUILDER_INVALID_PARAMETER_BRAIN');
+    throw new Error('URLBUILDER_INVALID_PARAMETER_BRAIN');
   }
 };

--- a/lib/device/brain/urlbuilder.js
+++ b/lib/device/brain/urlbuilder.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const DEFAULT_BRAIN_PORT = 3000;
+const PROTOCOL = 'http://';
+
+module.exports.buildBrainUrl = function(brain, baseUrl) {
+  if (!baseUrl){baseUrl='';}
+  if (brain.host && brain.port) {
+    return PROTOCOL + brain.host + ':' + brain.port + baseUrl;
+  }
+  return PROTOCOL + brain + ':' + DEFAULT_BRAIN_PORT + baseUrl;
+};

--- a/lib/device/brain/urlbuilder.js
+++ b/lib/device/brain/urlbuilder.js
@@ -4,9 +4,14 @@ const DEFAULT_BRAIN_PORT = 3000;
 const PROTOCOL = 'http://';
 
 module.exports.buildBrainUrl = function(brain, baseUrl) {
-  if (!baseUrl){baseUrl='';}
+  if (!baseUrl){
+    baseUrl='';
+  }
   if (brain.host && brain.port) {
     return PROTOCOL + brain.host + ':' + brain.port + baseUrl;
+  } else if (typeof brain === 'string'){
+    return PROTOCOL + brain + ':' + DEFAULT_BRAIN_PORT + baseUrl;
+  } else {
+    return new Error("URLBUILDER_INVALID_PARAMETER_BRAIN");
   }
-  return PROTOCOL + brain + ':' + DEFAULT_BRAIN_PORT + baseUrl;
 };

--- a/lib/device/brain/urlbuilder.js
+++ b/lib/device/brain/urlbuilder.js
@@ -4,6 +4,9 @@ const DEFAULT_BRAIN_PORT = 3000;
 const PROTOCOL = 'http://';
 
 module.exports.buildBrainUrl = function(brain, baseUrl) {
+  if (!brain){
+    return new Error('URLBUILDER_MISSING_PARAMETER_BRAIN');
+  }
   if (!baseUrl){
     baseUrl='';
   }

--- a/lib/recipe/index.js
+++ b/lib/recipe/index.js
@@ -4,24 +4,16 @@ const axios = require('axios');
 const BluePromise = require('bluebird');
 const debug = require('debug')('neeo:recipe:recipe');
 const factory = require('./factory');
+const urlbuilder = require('../device/brain/urlbuilder.js');
 
 const BASE_URL_GETRECIPES = '/v1/api/recipes';
 const BASE_URL_GETACTIVERECIPES = '/v1/api/activeRecipes';
-const DEFAULT_BRAIN_PORT = 3000;
-const PROTOCOL = 'http://';
-
-function buildBrainUrl(brain, baseUrl) {
-  if (brain.host && brain.port) {
-    return PROTOCOL + brain.host + ':' + brain.port + baseUrl;
-  }
-  return PROTOCOL + brain + ':' + DEFAULT_BRAIN_PORT + baseUrl;
-}
 
 module.exports.getAllRecipes = function(brain) {
   if (!brain) {
     return BluePromise.reject(new Error('MISSING_BRAIN_PARAMETER'));
   }
-  const url = buildBrainUrl(brain, BASE_URL_GETRECIPES);
+  const url = urlbuilder.buildBrainUrl(brain, BASE_URL_GETRECIPES);
   debug('getAllRecipes %s', url);
   return axios.get(url)
     .then((response) => {
@@ -33,7 +25,7 @@ module.exports.getRecipePowerState = function(brain) {
   if (!brain) {
     return BluePromise.reject(new Error('MISSING_BRAIN_PARAMETER'));
   }
-  const url = buildBrainUrl(brain, BASE_URL_GETACTIVERECIPES);
+  const url = urlbuilder.buildBrainUrl(brain, BASE_URL_GETACTIVERECIPES);
   debug('getRecipePowerState %s', url);
   return axios.get(url)
     .then((response) => {

--- a/test/unit/lib/device/brain/urlbuilder_test.js
+++ b/test/unit/lib/device/brain/urlbuilder_test.js
@@ -29,7 +29,7 @@ describe('./lib/device/brain/urlbuilder.js', function() {
   it('should fail to create url, with missing parameter', function() {
     expect(function() {
       urlbuilder.buildBrainUrl();
-    }).to.throw(/URLBUILDER_INVALID_PARAMETER_BRAIN/);
+    }).to.throw(/URLBUILDER_MISSING_PARAMETER_BRAIN/);
   });
 
     it('should fail to create url, with invalid parameter', function() {

--- a/test/unit/lib/device/brain/urlbuilder_test.js
+++ b/test/unit/lib/device/brain/urlbuilder_test.js
@@ -6,28 +6,36 @@ const BASE_URL_GETRECIPES = '/v1/api/recipes';
 
 describe('./lib/device/brain/urlbuilder.js', function() {
 
-  it('should return brain url when object is provided', function(done) {
+  it('should return brain url when object is provided', function() {
     const test = urlbuilder.buildBrainUrl({host:'test.local', port:6336});
     expect(test).to.equal('http://test.local:6336');
-    done();
   });
 
-  it('should return brain url when string is provided', function(done) {
+  it('should return brain url when string is provided', function() {
     const test = urlbuilder.buildBrainUrl('brain.local');
     expect(test).to.equal('http://brain.local:3000');
-    done();
   });
   
-  it('should return brain url and path when object is provided with uri', function(done) {
+  it('should return brain url and path when object is provided with uri', function() {
     const test = urlbuilder.buildBrainUrl({host:'test.local', port:6336}, BASE_URL_GETRECIPES);
     expect(test).to.equal('http://test.local:6336/v1/api/recipes');
-    done();
   });
 
-  it('should return brain url and path when string is provided with uri', function(done) {
+  it('should return brain url and path when string is provided with uri', function() {
     const test = urlbuilder.buildBrainUrl('brain.local', BASE_URL_GETRECIPES);
     expect(test).to.equal('http://brain.local:3000/v1/api/recipes');
-    done();
+  });
+
+  it('should fail to create url, with missing parameter', function() {
+    expect(function() {
+      urlbuilder.buildBrainUrl();
+    }).to.throw(/URLBUILDER_INVALID_PARAMETER_BRAIN/);
+  });
+
+    it('should fail to create url, with invalid parameter', function() {
+    expect(function() {
+      urlbuilder.buildBrainUrl(6336);
+    }).to.throw(/URLBUILDER_INVALID_PARAMETER_BRAIN/);
   });
 
 });

--- a/test/unit/lib/device/brain/urlbuilder_test.js
+++ b/test/unit/lib/device/brain/urlbuilder_test.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const expect = require('chai').expect;
+const urlbuilder = require('../../../../../lib/device/brain/urlbuilder.js');
+const BASE_URL_GETRECIPES = '/v1/api/recipes';
+
+describe('./lib/device/brain/urlbuilder.js', function() {
+
+  it('should return brain url when object is provided', function(done) {
+    const test = urlbuilder.buildBrainUrl({host:'test.local', port:6336});
+    expect(test).to.equal('http://test.local:6336');
+    done();
+  });
+
+  it('should return brain url when string is provided', function(done) {
+    const test = urlbuilder.buildBrainUrl('brain.local');
+    expect(test).to.equal('http://brain.local:3000');
+    done();
+  });
+  
+  it('should return brain url and path when object is provided with uri', function(done) {
+    const test = urlbuilder.buildBrainUrl({host:'test.local', port:6336}, BASE_URL_GETRECIPES);
+    expect(test).to.equal('http://test.local:6336/v1/api/recipes');
+    done();
+  });
+
+  it('should return brain url and path when string is provided with uri', function(done) {
+    const test = urlbuilder.buildBrainUrl('brain.local', BASE_URL_GETRECIPES);
+    expect(test).to.equal('http://brain.local:3000/v1/api/recipes');
+    done();
+  });
+
+});


### PR DESCRIPTION
-Added Urlbuilder.js with function buildBrainUrl(Brain, url)
-input types can be object and string for brain and the url can be passed but isn't required.
-Removed functions named buildBrainUrl.
-Changed the code that used the buildBrainUrl function to use Urlbuilder.buildBrainUrl.
-Added tests to test the code.


