### PR TITLE
Allow usage of Env Variable for Adapter IP Address

### DIFF
--- a/lib/device/index.js
+++ b/lib/device/index.js
@@ -62,7 +62,8 @@ function generateAdapterName(conf) {
 }
 
 function generateBaseUrl(conf) {
-  const ipaddress = validation.getAnyIpAddress();
+
+  const ipaddress = process.env.ADAPTERIP || validation.getAnyIpAddress();
   const baseUrl = 'http://' + ipaddress + ':' + conf.port;
   debug('Adapter baseUrl %s', baseUrl);
   return baseUrl;


### PR DESCRIPTION
Currently the Adapter BaseURL uses the first non internal IPv4 Address available with os.networkInterfaces()
On a Host with multiple Interfaces this could result in using a non reachable IP Address for the Brain. Or in a Dockerized Environment, it uses the internal Docker IP and thus the brain cannot contact the Device.
I suggest using an Environment Variable as an alternate to this behaviour.