### PR TITLE
Add port to devStart.js example

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ const BRAIN_IP = '10.0.0.10';
 neeoapi
   .startServer({
     brain: BRAIN_IP,
+    port: 6336,
     name: 'debug-server',
     devices: [
       driver,


### PR DESCRIPTION
I tried using this example to test a driver I just started working on and was puzzled about the INVALID_STARTSERVER_PARAMETER exception I was getting until I looked at the function throwing the exception and noticed that the port parameter is required. The port is also shown as required in the [SDK documentation]( https://neeoinc.github.io/neeo-sdk/#lib-index.js-module.exports.startserver), so this is the only place I found this error.