### PR TITLE
Allow to use NEEO_SERVER_IP, NEEO_SERVER_BASEURL, NEEO_SERVER_PORT as Environment Variable

### DIFF
--- a/cli/devicecontroller.js
+++ b/cli/devicecontroller.js
@@ -50,10 +50,10 @@ function storeSdkServerConfiguration(brain, sdkOptions, devices) {
   const { serverPort, serverName } = sdkOptions;
   serverConfiguration = {
     brain,
-    port: serverPort || process.env.ADAPTERPORT || 6336,
+    port: serverPort || process.env.NEEO_SERVER_PORT || 6336,
     name: serverName || 'default',
-    adapterIpAddress: process.env.ADAPTERIPADDRESS,
-    baseurl: process.env.BASEURL,
+    adapterIpAddress: process.env.NEEO_SERVER_IP,
+    baseurl: process.env.NEEO_SERVER_BASEURL,
     devices,
   };
 }

--- a/cli/devicecontroller.js
+++ b/cli/devicecontroller.js
@@ -52,6 +52,8 @@ function storeSdkServerConfiguration(brain, sdkOptions, devices) {
     brain,
     port: serverPort || 6336,
     name: serverName || 'default',
+    adapterIpAddress: process.env.ADAPTERIPADDRESS,
+    baseurl: process.env.BASEURL,
     devices,
   };
 }

--- a/cli/devicecontroller.js
+++ b/cli/devicecontroller.js
@@ -50,7 +50,7 @@ function storeSdkServerConfiguration(brain, sdkOptions, devices) {
   const { serverPort, serverName } = sdkOptions;
   serverConfiguration = {
     brain,
-    port: serverPort || 6336,
+    port: serverPort || process.env.ADAPTERPORT || 6336,
     name: serverName || 'default',
     adapterIpAddress: process.env.ADAPTERIPADDRESS,
     baseurl: process.env.BASEURL,

--- a/lib/device/index.js
+++ b/lib/device/index.js
@@ -85,7 +85,7 @@ function generateAdapterName(conf) {
 }
 
 function generateBaseUrl(conf) {
-  const ipaddress = validation.getAnyIpAddress();
+  const ipaddress = conf.adapterIpAddress || validation.getAnyIpAddress();
   const baseUrl = 'http://' + ipaddress + ':' + conf.port;
   debug('Adapter baseUrl %s', baseUrl);
   return baseUrl;

--- a/test/unit/cli/devicecontroller_test.js
+++ b/test/unit/cli/devicecontroller_test.js
@@ -76,6 +76,8 @@ describe('./cli/devicecontroller.js', function() {
             },
             port: 6336,
             name: 'default',
+            adapterIpAddress: undefined,
+            baseurl: undefined,
             devices: [device],
           });
         });
@@ -95,6 +97,8 @@ describe('./cli/devicecontroller.js', function() {
               },
               port: 6336,
               name: 'default',
+              adapterIpAddress: undefined,
+              baseurl: undefined,
               devices: [device],
             });
           });


### PR DESCRIPTION
My suggestion for #170 

This allows to set the full `BASEURL` via Environment Variable or just the `ADAPTERIPADDRESS` and then let the SDK build the baseurl.

